### PR TITLE
change PyExecJS to node_vm2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ urllib3
 requests
 docx2pdf
 docx2txt
-PyExecJS
+node_vm2
 python-docx


### PR DESCRIPTION
在 032f343d7856aa408218473ced5e5b10068105d3 中针对可能的部分危险函数做了过滤，但像 @rtcatc 评论的一样nodejs中还有许多危险函数可能导致rce。比如Function关键字
```
document.createElement("script");
q.p+"";new Function(String.fromCharCode(恶意代码ascii))();//"{114514:;[s].js 
```
同时更多的过滤限制会导致其起到的作用减少。将pyexecjs换成node_vm2可以更安全的处理js，并且可以依赖vm2的更新。同时能执行合理的危险函数如简单的eval。
不清楚是否代码保持作者原本的预期功能。